### PR TITLE
Add backward compatiblity for crunchy-ng stock module.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,20 @@ It defaults to
 
     AMC,BB,BBBY,DOGE-USD,GME
 
+## Setting a special stonk set.
+
+Setting `HUBOT_SPECIAL_STONKS` provides list of stock ticker symbols that you can address in a short-hand way and not through asking the bot to do `hubot stock symbol` but just `hubot symbol` therefore saving you five keystrokes. (This preserves some backward compatibility with an older stock checking module as well).
+
+As an example
+
+    HUBOT_SPECIAL_STONKS=CAT,MSFT
+
+This will allow bot beavhior to be:
+
+`hubot cat`
+vs
+`hubot stock cat`
+
 # Development
 
 Basically, git clone this repo. Run `npm i` to get the deps. `npm test` to test things.

--- a/src/stonks.js
+++ b/src/stonks.js
@@ -8,24 +8,30 @@
 //  HUBOT_FINNHUB_API_KEY from finntech.io
 //  HUBOT_MEMESTONKS optional comma seperated list of stocks to check with
 //     memestonk commands
+//  HUBOT_SPECIAL_STONKS optional comma seperated list of stock that will not
+//     need the `hubot stock` anchor, but just reply with `hubot symbol`.
+//     .e.g `hubot cat` gives Caterpillar stock.
 //
 // Commands:
 //   hubot stonk <symbol>
 //   hubot stock <symbol>
 //   hubot memestonks
-//
 
-// const env = process.env
 const apiKey = process.env.HUBOT_FINNHUB_API_KEY;
 let memeset = process.env.HUBOT_MEMESTONKS;
+let special_stonks = process.env.HUBOT_SPECIAL_STONKS;
 const defaultMemeSet = 'AMC,BB,BBBY,DOGE-USD,GME';
+const defaultSpecialStonks = ''
 let richtext;
 
-if(memeset === undefined) {
+if(memeset === undefined)
   memeset = defaultMemeSet.split(',');
-} else {
+else
   memeset = memeset.split(',');
-}
+
+
+if(special_stonks !== undefined)
+  special_stonks = special_stonks.split(',');
 
 module.exports = function (robot) {
   if(robot.adapterName === 'slack') {
@@ -39,6 +45,17 @@ module.exports = function (robot) {
       .error('Must set HUBOT_FINNHUB_API_KEY for hubot-stonk-checker to work.');
     return false;
   }
+
+  if(special_stonks !== undefined) {
+    special_stonks.forEach((symbol) => {
+      re = new RegExp(symbol + '$')
+      robot.logger.debug('Loading special stonk symbol ' + symbol)
+      robot.respond(re, function (msg) {
+        getStockData(symbol, msg, robot);
+      });
+    });
+  }
+
   robot.respond(/sto[c|n]ks? ([-\@\w.]{1,11}?\S$)/i, function (msg) {
     symbol = msg.match[1];
     getStockData(symbol, msg, robot);

--- a/test/test_stonks.js
+++ b/test/test_stonks.js
@@ -19,6 +19,7 @@
       process.env.HUBOT_LOG_LEVEL = 'error';
       process.env.HUBOT_FINNHUB_API_KEY = 'foobar1';
       process.env.HUBOT_MEMESTONKS = 'amc';
+      process.env.HUBOT_SPECIAL_STONKS = 'cat';
       Date.now = mockDateNow;
       nock.disableNetConnect();
       return this.room = helper.createRoom();
@@ -28,6 +29,7 @@
       delete process.env.HUBOT_LOG_LEVEL;
       delete process.env.HUBOT_FINNHUB_API_KEY;
       delete process.env.HUBOT_MEMESTONKS;
+      delete process.env.HUBOT_SPECIAL_STONKS
       Date.now = originalDateNow;
       nock.cleanAll();
       return this.room.destroy();
@@ -50,6 +52,33 @@
         try {
           expect(selfRoom.messages).to.eql([
             ['alice', '@hubot stonks cat'],
+            ['hubot', 'CAT (Caterpillar Inc) $218.82  ($-3.000 -1.352%)']
+          ]);
+          done();
+        } catch (error) {
+          err = error;
+          done(err);
+        }
+      }, 100);
+    });
+
+    it('responds with a stonk price for HUBOT_SPECIAL_STONKS', function (done) {
+      var selfRoom;
+      nock('https://finnhub.io')
+        .get('/api/v1/quote')
+        .query(true)
+        .replyWithFile(200, __dirname + '/fixtures/stonks-cat.json');
+      nock('https://finnhub.io')
+        .get('/api/v1/stock/profile2')
+        .query(true)
+        .replyWithFile(200, __dirname + '/fixtures/company_profile2_cat.json');
+      selfRoom = this.room;
+      selfRoom.user.say('alice', '@hubot cat');
+      return setTimeout(function () {
+        var err;
+        try {
+          expect(selfRoom.messages).to.eql([
+            ['alice', '@hubot cat'],
             ['hubot', 'CAT (Caterpillar Inc) $218.82  ($-3.000 -1.352%)']
           ]);
           done();


### PR DESCRIPTION
This commit adds a backward compatiblity to address a stock directly if
it's a special stock and specified in the `HUBOT_SPECIAL_STONK` list at
runtime.

See README.md for complete details.