### PR TITLE
Add URLs to yahoo finance in output for rich text.

### DIFF
--- a/src/stonks.js
+++ b/src/stonks.js
@@ -122,15 +122,19 @@ module.exports = function (robot) {
         }
         result = JSON.parse(body);
         robot.logger.debug('Body from url:', body);
+        yFinUrl = "";
+        if (richtext)
+        {
+          yFinUrl = 'https://finance.yahoo.com/quote/' + symbol;
+          robot.logger.debug("Yahoo Finance URL: ", yFinUrl);
+          symbolstr = '<' + yFinUrl + '|' + symbol + '>';
+        }
         // Body returns
         // { c: 256.89, h: 296, l: 252.01, o: 282, pc: 193.6, t: 1611878400 }
         delta = parseFloat(result.c - result.pc).toFixed(3);
         printdelta = delta;
         if (delta > 0.0) {
           printdelta = '+' + delta;
-        }
-        else {
-          printdelta = delta;
         }
         perc = parseFloat(delta / result.pc * 100).toFixed(3);
         if (perc > 0.0)
@@ -141,7 +145,18 @@ module.exports = function (robot) {
         // Currencies do not have companyData
         message = symbol + ' $' + result.c + ' ($' + printdelta + ' ' + printperc + ')';
         if (companyData && typeof companyData.name !== 'undefined' && companyData.name !== null) {
-          message = symbol + ' (' + companyData.name + ') ' + '$' + result.c + '  ($' + printdelta + ' ' + printperc + ')';
+          if(yFinUrl)
+            message = symbolstr;
+          else
+            message = symbol;
+          message += ' (' + companyData.name + ') ' + '$' + result.c + '  ($' + printdelta + ' ' + printperc + ')';
+        }
+        else {
+          if(yFinUrl)
+            message = symbolstr;
+          else
+            message = symbol;
+          message += ' $' + result.c + ' ($' + printdelta + ' ' + printperc + ')';
         }
         if (richtext) {
           if (delta > 0.0)
@@ -158,6 +173,8 @@ module.exports = function (robot) {
         }
         if (result.pc == 0)
           message = symbol + ' ticker symbol not found.';
+        if(richtext)
+          message = { "text": message, "unfurl_links": false, "unfurl_media": false };
         msg.send(message);
       });
   }

--- a/src/stonks.js
+++ b/src/stonks.js
@@ -29,20 +29,20 @@ module.exports = function (robot) {
   const quoteBaseUrl = 'https://finnhub.io/api/v1/quote';
   const companyBaseUrl = 'https://finnhub.io/api/v1/stock/profile2';
 
-  if (typeof apiKey === 'undefined' || apiKey === null) {
+  if(typeof apiKey === 'undefined' || apiKey === null) {
     robot.logger
       .error('Must set HUBOT_FINNHUB_API_KEY for hubot-stonk-checker to work.');
   }
 
-  if (typeof memeset === "undefined" || memeset === null)
+  if(typeof memeset === "undefined" || memeset === null)
     memeset = defaultMemeSet.split(',');
   else
     memeset = memeset.split(',');
 
-  if (robot.adapterName === 'slack')
+  if(robot.adapterName === 'slack')
     richtext = true;
 
-  if (typeof special_stonks !== 'undefined' && special_stonks !== null) {
+  if(typeof special_stonks !== 'undefined' && special_stonks !== null) {
     special_stonks = special_stonks.split(',');
     special_stonks.forEach((symbol) => {
       re = new RegExp(symbol + '$', 'i');
@@ -64,7 +64,7 @@ module.exports = function (robot) {
   });
 
   robot.respond(/memestonks?\S$$/i, (msg) => {
-    if (richtext) {
+    if(richtext) {
       msg.send(':wsb:');
     }
     memeset.forEach((symbol) => {
@@ -75,7 +75,7 @@ module.exports = function (robot) {
   function formatSymbol(symbol) {
     symbol = symbol.toUpperCase();
     // If it's a common crypto currency abbreviation, help the user out.
-    if (['DOGE', 'BTC', 'XRP', 'ETH'].includes(symbol)) {
+    if(['DOGE', 'BTC', 'XRP', 'ETH'].includes(symbol)) {
       symbol += '-USD';
     }
     return symbol;
@@ -89,13 +89,13 @@ module.exports = function (robot) {
         symbol: symbol
       })
       .get()((err, res, body) => {
-        if (err) {
+        if(err) {
           robot.logger.error(err);
           msg.send('Encountered an error: ' + err.toString());
           return;
         }
         data = JSON.parse(body);
-        if (data && typeof data.error !== 'undefined') {
+        if(data && typeof data.error !== 'undefined') {
           robot.logger.error(data);
           msg.send('Error! Make sure you have set HUBOT_FINNHUB_API_KEY.');
           return;
@@ -115,7 +115,7 @@ module.exports = function (robot) {
       .get()(function (err, res, body) {
         robot.logger.debug('Url being called in getStockQuote is', res.req.path);
         var printperc, delta, printdelta, message;
-        if (err) {
+        if(err) {
           robot.logger.error(err);
           msg.send('Encountered an error: ' + err.toString());
           return;
@@ -123,8 +123,7 @@ module.exports = function (robot) {
         result = JSON.parse(body);
         robot.logger.debug('Body from url:', body);
         yFinUrl = "";
-        if (richtext)
-        {
+        if(richtext) {
           yFinUrl = 'https://finance.yahoo.com/quote/' + symbol;
           robot.logger.debug("Yahoo Finance URL: ", yFinUrl);
           symbolstr = '<' + yFinUrl + '|' + symbol + '>';
@@ -133,48 +132,51 @@ module.exports = function (robot) {
         // { c: 256.89, h: 296, l: 252.01, o: 282, pc: 193.6, t: 1611878400 }
         delta = parseFloat(result.c - result.pc).toFixed(3);
         printdelta = delta;
-        if (delta > 0.0) {
+        if(delta > 0.0) {
           printdelta = '+' + delta;
         }
         perc = parseFloat(delta / result.pc * 100).toFixed(3);
-        if (perc > 0.0)
+        if(perc > 0.0)
           printperc = '+' + perc + '%';
         else
           printperc = perc + '%';
 
         // Currencies do not have companyData
         message = symbol + ' $' + result.c + ' ($' + printdelta + ' ' + printperc + ')';
-        if (companyData && typeof companyData.name !== 'undefined' && companyData.name !== null) {
+        if(companyData && typeof companyData.name !== 'undefined' && companyData.name !== null) {
           if(yFinUrl)
             message = symbolstr;
           else
             message = symbol;
           message += ' (' + companyData.name + ') ' + '$' + result.c + '  ($' + printdelta + ' ' + printperc + ')';
-        }
-        else {
+        } else {
           if(yFinUrl)
             message = symbolstr;
           else
             message = symbol;
           message += ' $' + result.c + ' ($' + printdelta + ' ' + printperc + ')';
         }
-        if (richtext) {
-          if (delta > 0.0)
+        if(richtext) {
+          if(delta > 0.0)
             message = ':stonks: ' + message;
-          if (delta < 0.0)
+          if(delta < 0.0)
             message = ':stonks-down: ' + message;
-          if (delta == 0.0)
+          if(delta == 0.0)
             message = message;
-          if (symbol == 'DOGE-USD') {
+          if(symbol == 'DOGE-USD') {
             message = ':doge: ' + message;
           }
-          if (perc > 15.00)
+          if(perc > 15.00)
             message = message + '\n :gem: :raised_hands: :rocket: :rocket: :rocket: :moon:';
         }
-        if (result.pc == 0)
+        if(result.pc == 0)
           message = symbol + ' ticker symbol not found.';
         if(richtext)
-          message = { "text": message, "unfurl_links": false, "unfurl_media": false };
+          message = {
+            "text": message,
+            "unfurl_links": false,
+            "unfurl_media": false
+          };
         msg.send(message);
       });
   }

--- a/test/test_stonks.js
+++ b/test/test_stonks.js
@@ -12,59 +12,101 @@ describe('hubot-stonk-checker (plain text)', function () {
   beforeEach(function () {
     nock('https://finnhub.io')
       .get('/api/v1/quote')
-      .query({token: 'foobar1', symbol: 'CAT'})
+      .query({
+        token: 'foobar1',
+        symbol: 'CAT'
+      })
       .replyWithFile(200, __dirname + '/fixtures/stonks-cat.json');
     nock('https://finnhub.io')
       .get('/api/v1/stock/profile2')
-      .query({token: 'foobar1', symbol: 'CAT'})
+      .query({
+        token: 'foobar1',
+        symbol: 'CAT'
+      })
       .replyWithFile(200, __dirname + '/fixtures/company_profile2_cat.json');
     nock('https://finnhub.io')
       .get('/api/v1/quote')
-      .query({token: 'foobar1', symbol: 'DOGE-USD'})
+      .query({
+        token: 'foobar1',
+        symbol: 'DOGE-USD'
+      })
       .replyWithFile(200, __dirname + '/fixtures/stonks-doge-usd.json');
     nock('https://finnhub.io')
       .get('/api/v1/stock/profile2')
-      .query({token: 'foobar1', symbol: 'DOGE-USD'})
+      .query({
+        token: 'foobar1',
+        symbol: 'DOGE-USD'
+      })
       .reply(200, "{}");
     nock('https://finnhub.io')
       .get('/api/v1/quote')
-      .query({token: 'foobar1', symbol: 'BTC-USD'})
+      .query({
+        token: 'foobar1',
+        symbol: 'BTC-USD'
+      })
       .replyWithFile(200, __dirname + '/fixtures/stonks-btc-usd.json');
     nock('https://finnhub.io')
       .get('/api/v1/stock/profile2')
-      .query({token: 'foobar1', symbol: 'BTC-USD'})
+      .query({
+        token: 'foobar1',
+        symbol: 'BTC-USD'
+      })
       .reply(200, "{}");
     nock('https://finnhub.io')
       .get('/api/v1/quote')
-      .query({token: 'foobar1', symbol: 'XRP-USD'})
+      .query({
+        token: 'foobar1',
+        symbol: 'XRP-USD'
+      })
       .replyWithFile(200, __dirname + '/fixtures/stonks-xrp-usd.json');
     nock('https://finnhub.io')
       .get('/api/v1/stock/profile2')
-      .query({token: 'foobar1', symbol: 'XRP-USD'})
+      .query({
+        token: 'foobar1',
+        symbol: 'XRP-USD'
+      })
       .reply(200, "{}");
     nock('https://finnhub.io')
       .get('/api/v1/quote')
-      .query({token: 'foobar1', symbol: 'AJAJAJ'})
+      .query({
+        token: 'foobar1',
+        symbol: 'AJAJAJ'
+      })
       .replyWithFile(200, __dirname + '/fixtures/stonks-notfound.json');
     nock('https://finnhub.io')
       .get('/api/v1/stock/profile2')
-      .query({token: 'foobar1', symbol: 'AJAJAJ'})
+      .query({
+        token: 'foobar1',
+        symbol: 'AJAJAJ'
+      })
       .reply(200, "{}");
     nock('https://finnhub.io')
       .get('/api/v1/quote')
-      .query({token: 'foobar1', symbol: 'AMC'})
+      .query({
+        token: 'foobar1',
+        symbol: 'AMC'
+      })
       .replyWithFile(200, __dirname + '/fixtures/stonks-amc.json');
     nock('https://finnhub.io')
       .get('/api/v1/stock/profile2')
-      .query({token: 'foobar1', symbol: 'AMC'})
+      .query({
+        token: 'foobar1',
+        symbol: 'AMC'
+      })
       .replyWithFile(200, __dirname + '/fixtures/company_profile2_amc.json');
     nock('https://finnhub.io')
       .get('/api/v1/quote')
-      .query({token: '', symbol: 'CAT'})
+      .query({
+        token: '',
+        symbol: 'CAT'
+      })
       .replyWithFile(401, __dirname + '/fixtures/stonks-missing-api-key.json');
     nock('https://finnhub.io')
       .get('/api/v1/stock/profile2')
-      .query({token: '', symbol: 'CAT'})
+      .query({
+        token: '',
+        symbol: 'CAT'
+      })
       .replyWithFile(401, __dirname + '/fixtures/stonks-missing-api-key.json');
   });
 
@@ -230,14 +272,14 @@ describe('hubot-stonk-checker (plain text)', function () {
         hear: sinon.spy()
       };
     });
-  
+
     afterEach(function () {
       room.destroy();
       nock.cleanAll();
       delete process.env.HUBOT_LOG_LEVEL;
       delete process.env.HUBOT_FINNHUB_API_KEY;
     });
-  
+
     it('responds with an error message', function (done) {
       room.user.say('alice', '@hubot stonks cat');
       return setTimeout(function () {

--- a/test/test_stonks_slack.js
+++ b/test/test_stonks_slack.js
@@ -12,35 +12,59 @@ describe('hubot-stonk-checker (rich formatting)', function () {
   beforeEach(function () {
     nock('https://finnhub.io')
       .get('/api/v1/quote')
-      .query({token: 'foobar1', symbol: 'CAT'})
+      .query({
+        token: 'foobar1',
+        symbol: 'CAT'
+      })
       .replyWithFile(200, __dirname + '/fixtures/stonks-cat.json');
     nock('https://finnhub.io')
       .get('/api/v1/stock/profile2')
-      .query({token: 'foobar1', symbol: 'CAT'})
+      .query({
+        token: 'foobar1',
+        symbol: 'CAT'
+      })
       .replyWithFile(200, __dirname + '/fixtures/company_profile2_cat.json');
     nock('https://finnhub.io')
       .get('/api/v1/quote')
-      .query({token: 'foobar1', symbol: 'DOGE-USD'})
+      .query({
+        token: 'foobar1',
+        symbol: 'DOGE-USD'
+      })
       .replyWithFile(200, __dirname + '/fixtures/stonks-cat.json');
     nock('https://finnhub.io')
       .get('/api/v1/stock/profile2')
-      .query({token: 'foobar1', symbol: 'DOGE-USD'})
+      .query({
+        token: 'foobar1',
+        symbol: 'DOGE-USD'
+      })
       .reply(200, "{}");
     nock('https://finnhub.io')
       .get('/api/v1/quote')
-      .query({token: 'foobar1', symbol: 'AMC'})
+      .query({
+        token: 'foobar1',
+        symbol: 'AMC'
+      })
       .replyWithFile(200, __dirname + '/fixtures/stonks-amc.json');
     nock('https://finnhub.io')
       .get('/api/v1/stock/profile2')
-      .query({token: 'foobar1', symbol: 'AMC'})
+      .query({
+        token: 'foobar1',
+        symbol: 'AMC'
+      })
       .replyWithFile(200, __dirname + '/fixtures/company_profile2_amc.json');
     nock('https://finnhub.io')
       .get('/api/v1/quote')
-      .query({token: 'foobar1', symbol: 'GME'})
+      .query({
+        token: 'foobar1',
+        symbol: 'GME'
+      })
       .replyWithFile(200, __dirname + '/fixtures/stonks-gme.json');
     nock('https://finnhub.io')
       .get('/api/v1/stock/profile2')
-      .query({token: 'foobar1', symbol: 'GME'})
+      .query({
+        token: 'foobar1',
+        symbol: 'GME'
+      })
       .replyWithFile(200, __dirname + '/fixtures/company_profile2_gme.json');
   });
 
@@ -71,7 +95,11 @@ describe('hubot-stonk-checker (rich formatting)', function () {
         try {
           expect(room.messages).to.eql([
             ['alice', '@hubot stonks cat'],
-            ['hubot', ':stonks-down: CAT (Caterpillar Inc) $218.82  ($-3.000 -1.352%)']
+            ['hubot', {
+              'text': ":stonks-down: <https://finance.yahoo.com/quote/CAT|CAT> (Caterpillar Inc) $218.82  ($-3.000 -1.352%)",
+              "unfurl_links": false,
+              "unfurl_media": false
+            }]
           ]);
           done();
         } catch (err) {
@@ -86,7 +114,11 @@ describe('hubot-stonk-checker (rich formatting)', function () {
         try {
           expect(room.messages).to.eql([
             ['alice', '@hubot stonks gme'],
-            ['hubot', ':stonks: GME (GameStop Corp) $191.495  ($+82.765 +76.120%)\n :gem: :raised_hands: :rocket: :rocket: :rocket: :moon:']
+            ['hubot', {
+              'text': ":stonks: <https://finance.yahoo.com/quote/GME|GME> (GameStop Corp) $191.495  ($+82.765 +76.120%)\n :gem: :raised_hands: :rocket: :rocket: :rocket: :moon:",
+              "unfurl_links": false,
+              "unfurl_media": false
+            }]
           ]);
           done();
         } catch (err) {
@@ -101,7 +133,11 @@ describe('hubot-stonk-checker (rich formatting)', function () {
         try {
           expect(room.messages).to.eql([
             ['alice', '@hubot stonks doge'],
-            ['hubot', ':doge: :stonks-down: DOGE-USD $218.82 ($-3.000 -1.352%)']
+            ['hubot', {
+              'text': ":doge: :stonks-down: <https://finance.yahoo.com/quote/DOGE-USD|DOGE-USD> $218.82 ($-3.000 -1.352%)",
+              "unfurl_links": false,
+              "unfurl_media": false
+            }]
           ]);
           done();
         } catch (err) {
@@ -117,7 +153,11 @@ describe('hubot-stonk-checker (rich formatting)', function () {
           expect(room.messages).to.eql([
             ['alice', '@hubot memestonks'],
             ['hubot', ':wsb:'],
-            ['hubot', ':stonks-down: AMC (AMC Entertainment Holdings Inc) $7.93  ($-0.360 -4.343%)']
+            ['hubot', {
+              'text': ":stonks-down: <https://finance.yahoo.com/quote/AMC|AMC> (AMC Entertainment Holdings Inc) $7.93  ($-0.360 -4.343%)",
+              "unfurl_links": false,
+              "unfurl_media": false
+            }]
           ]);
           done();
         } catch (err) {
@@ -127,13 +167,17 @@ describe('hubot-stonk-checker (rich formatting)', function () {
     });
 
     it('displays memestonks with a diff env var (rich formatting)', function (done) {
-    room.user.say('alice', '@hubot memestonks');
+      room.user.say('alice', '@hubot memestonks');
       return setTimeout(function () {
         try {
           expect(room.messages).to.eql([
             ['alice', '@hubot memestonks'],
             ['hubot', ':wsb:'],
-            ['hubot', ':stonks-down: AMC (AMC Entertainment Holdings Inc) $7.93  ($-0.360 -4.343%)']
+            ['hubot', {
+              'text': ":stonks-down: <https://finance.yahoo.com/quote/AMC|AMC> (AMC Entertainment Holdings Inc) $7.93  ($-0.360 -4.343%)",
+              "unfurl_links": false,
+              "unfurl_media": false
+            }]
           ]);
           done();
         } catch (err) {


### PR DESCRIPTION
This commit adds rich messages with a url (and links not unfurled) for
symbols. Originally this was going to use Google Finance, but the not
100% deterministic nature of the URI led me to use Yahoo! Finance, which
is much easier programatically put together.

Fixes #12