### PR TITLE
Allow `hubot stonks` to trigger `memestonks` result

### DIFF
--- a/src/stonks.js
+++ b/src/stonks.js
@@ -63,7 +63,7 @@ module.exports = function (robot) {
     getStockData(symbol, msg, robot);
   });
 
-  robot.respond(/memestonks?\S$$/i, (msg) => {
+  robot.respond(/(?:memestonk|stonk)s?\S$$/i, (msg) => {
     if(richtext) {
       msg.send(':wsb:');
     }


### PR DESCRIPTION
Prior to this PR, a user had to remember to type out `hubot memestonks` to get the list of configured meme stocks. This PR allows that to be shortened up to just `hubot stonks` for the same effect.